### PR TITLE
Documentation Simplification: Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ clean:
 	find . -type d -name '__pycache__' -delete
 
 ## run: gas station event indexer
-run: install
+run:
 	@$(PYTHON) gas_station_event_indexer.py
 
 help:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+# Configuration
+VENV_NAME ?= .venv
+PYTHON := $(VENV_NAME)/bin/python3
+PIP := $(VENV_NAME)/bin/pip
+REQUIREMENTS ?= requirements.txt
+
+.PHONY: install clean
+
+## install: create a virtual environment and install dependencies
+install: $(VENV_NAME)
+	@echo "Installing dependencies..."
+	@$(PIP) install -r $(REQUIREMENTS)
+
+$(VENV_NAME): 
+	@test -d $(VENV_NAME) || python3 -m venv $(VENV_NAME)
+
+## clean: remove virtual environment and temporary files
+clean:
+	@echo "Cleaning up..."
+	rm -rf $(VENV_NAME)
+	find . -type f -name '*.pyc' -delete
+	find . -type d -name '__pycache__' -delete
+
+## run: gas station event indexer
+run: install
+	@$(PYTHON) gas_station_event_indexer.py
+
+help:
+	@echo "Makefile for Python project with venv"
+	@echo
+	@echo "Usage:"
+	@echo "  make install      create a virtual environment and install dependencies"
+	@echo "  make clean        remove virtual environment and temporary files"
+	@echo "  make help         show this help message"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # gas-station-event-indexer
-Picks up events emitted from the gas station contract used for generating signed foreign chain transactions and calls the multichain relayer /send_funding_and_user_signed_txns endpoint locally
+Picks up events emitted from the gas station contract used for generating signed foreign chain transactions and calls the multichain relayer `/send_funding_and_user_signed_txns` endpoint locally
 
 # Run
 1. ensure you have https://github.com/near/multichain-relayer-server running on localhost:3030
-2. Create and activate a python virtual environment and `pip install requirements.txt`
-3. update the config.toml with the appropriate values
-4. `python3 gas-station-event-indexer.py`
+2. update the config.toml with the appropriate values
+3. `make run` - this will create a virtual environment, install dependencies and run `gas_station_event_indexer.py`

--- a/README.md
+++ b/README.md
@@ -3,5 +3,6 @@ Picks up events emitted from the gas station contract used for generating signed
 
 # Run
 1. ensure you have https://github.com/near/multichain-relayer-server running on localhost:3030
+2. `make install` create virtual environment and install `requirements.txt`
 2. update the config.toml with the appropriate values
-3. `make run` - this will create a virtual environment, install dependencies and run `gas_station_event_indexer.py`
+3. `make run` runs the `gas_station_event_indexer.py` script


### PR DESCRIPTION
Personally, I can never remember how to create and activate a virtual environment (even though I have done is hundreds of times). This PR simplifies the following chain of commands into just `make run`:

```sh
python3 -m venv .venv
source .venv/bin/activate
```
into `make install`

and 

```sh
python gas_station_event_indexer.py
```
into `make run`. 

Technically it is possible to run `install` within the `run` command, but then users will always see this long list of `Requirement already satisfied` which is ugly.

The README is updated and if merged, I would make a follow up PR to wherever this [docs page](https://docs.near.org/build/chain-abstraction/multichain-gas-relayer/relayer-gas-example) happens to live.