### PR TITLE
Fix Deprecation Warning

### DIFF
--- a/gas_station_event_indexer.py
+++ b/gas_station_event_indexer.py
@@ -141,5 +141,5 @@ async def main():
         await handle_streamer_message(streamer_message)
 
 
-loop = asyncio.get_event_loop()
+loop = asyncio.new_event_loop()
 loop.run_until_complete(main())


### PR DESCRIPTION
Fixes the:

```
gas_station_event_indexer.py:144: DeprecationWarning: There is no current event loop
  loop = asyncio.get_event_loop()
```

Depending on the python version you're targeting, this has been deprecated since 3.10. Simple fix is pretty straightforward so I thought I would add it. If you don't mind, I would like to add a CI file to this project in a follow up PR (and we can test this against a range of python versions (say 3.10 to 3.12).