### PR TITLE
Adapting to Lastet Near Lake Framework

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Python 3.12
+      - name: Setup Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.11'
       - name: Install Requirements
         run:
           pip install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+include .env
+
+export $(shell sed 's/=.*//' .env)
+
 # Configuration
 VENV_NAME ?= .venv
 PYTHON := $(VENV_NAME)/bin/python3

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 Picks up events emitted from the gas station contract used for generating signed foreign chain transactions and calls the multichain relayer `/send_funding_and_user_signed_txns` endpoint locally
 
 # Run
-1. ensure you have https://github.com/near/multichain-relayer-server running on localhost:3030
+1. Ensure you have https://github.com/near/multichain-relayer-server running on localhost:3030
 2. `make install` create virtual environment and install `requirements.txt`
-3. update the config.toml with the appropriate values
+3. Update the config.toml with the appropriate values
 4. `make run` runs the `gas_station_event_indexer.py` script
+
+*Note that* you will also have to populate an environment file
+```shell
+cp .env.example .env
+```
+containing AWS credentials for reading from [Near Lake](https://docs.near.org/tools/realtime#near-lake-indexer).

--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ Picks up events emitted from the gas station contract used for generating signed
 # Run
 1. ensure you have https://github.com/near/multichain-relayer-server running on localhost:3030
 2. `make install` create virtual environment and install `requirements.txt`
-2. update the config.toml with the appropriate values
-3. `make run` runs the `gas_station_event_indexer.py` script
+3. update the config.toml with the appropriate values
+4. `make run` runs the `gas_station_event_indexer.py` script

--- a/gas_station_event_indexer.py
+++ b/gas_station_event_indexer.py
@@ -4,7 +4,6 @@ import asyncio
 import json
 import os
 from dataclasses import dataclass, fields
-from enum import Enum
 from typing import Optional, Any
 
 import requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 asyncio>=3.4.3
 near-lake-framework>=0.0.8
-requests>=2.31.0
+requests>=2.32.0
 toml>=0.10.2
 
 black>=24.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-asyncio==3.4.3
-near-lake-framework==0.0.7
-requests==2.31.0
-toml==0.10.2
+asyncio>=3.4.3
+near-lake-framework>=0.0.8
+requests>=2.31.0
+toml>=0.10.2
 
 black>=24.4.0
 pylint>=3.1.0


### PR DESCRIPTION
1. Drop CI python version to 3.11 (near lake framework doesn't work with 3.12)
2. Load .env in Makefile
3. [Minor] Fix enumeration in Readme
4. 🔑 Adapt main file to use latest near-lake-framework
5. Use >= on requirements file (also version bump near-lake-framework to 0.0.8)
6. Add AWS env details to readme (closes #7)