### PR TITLE
Remove Log Filter

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,3 @@
 network = "testnet"
 # gas station contract account id
 contract_id = "canhazgas.testnet"
-log_level = "info"

--- a/logger.py
+++ b/logger.py
@@ -1,37 +1,7 @@
 import logging
 
 
-class IgnoreFilter(logging.Filter):
-    """
-    Customized Log filter that ignores a given message text.
-    """
-
-    def __init__(self, ignored_message: str, name: str = "") -> None:
-        super().__init__(name)
-        self.ignored_message = ignored_message
-        self.enabled = True
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        if not self.enabled:
-            return True
-        return self.ignored_message not in record.getMessage()
-
-    def set_ignored_message(self, message: str) -> None:
-        """Set a new message pattern to ignore."""
-        self.ignored_message = message
-
-    def toggle_filter(self, enable: bool) -> None:
-        """Enable or disable the filter."""
-        self.enabled = enable
-
-    def get_ignored_message(self) -> str:
-        """Get the current ignored message pattern."""
-        return self.ignored_message
-
-
 def set_logger(name: str, level: int | str) -> logging.Logger:
     logging.basicConfig(level=level)
     logging.getLogger("near_lake_framework").setLevel(logging.INFO)
-    missing_shard_filter = IgnoreFilter("doesn't exist")
-    logging.getLogger().addFilter(missing_shard_filter)
     return logging.getLogger(name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 asyncio>=3.4.3
-near-lake-framework>=0.1.0
+near-lake-framework>=0.1.1
 requests>=2.32.0
 toml>=0.10.2
 


### PR DESCRIPTION
Closes #11 

In a follow up PR we will address #12.

Note that we also remove `log_level` from sample config because it was crashing the parser (unexpected field).

## Test Plan

```sh
make install
make run
```

Watch those sweet-sweet logs